### PR TITLE
Fix up reviewdog

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,6 @@ EXIT_CODE=$?
 
 cat /tmp/phpcs_result_checkstyle.xml
 
-< /tmp/phpcs_result_checkstyle.xml | reviewdog -f=checkstyle -name="phpcs" -reporter="${INPUT_REPORTER:-github-pr-check}"
+< /tmp/phpcs_result_checkstyle.xml reviewdog -f=checkstyle -name="phpcs" -reporter="${INPUT_REPORTER:-github-pr-check}"
 
 exit $EXIT_CODE


### PR DESCRIPTION
This PR fixes the reviewdog command so that it receives the phpcs report file contents.

The command used redirection of stdin to read in the file, e.g. `< filename` but this was piped, connecting the empty stdout to reviewdog's stdin (I guess?). 

Without the pipe it should work. Now the redirection of stdin grabs the file contents and this is the stdin of reviewdog.